### PR TITLE
monitoring working end-to-end

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -362,3 +362,5 @@ MigrationBackup/
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
 .azure
+**/*local.json
+**/*arm.json

--- a/ReadR.AppHost/AppHost.cs
+++ b/ReadR.AppHost/AppHost.cs
@@ -2,12 +2,16 @@ using Azure.Provisioning.Storage;
 
 var builder = DistributedApplication.CreateBuilder(args);
 
+// Add the Application Insights telemetry
+var readrinsights = builder.AddAzureApplicationInsights("readrinsights");
+
 // Add the Azure Container App environment
 builder.AddAzureContainerAppEnvironment("readracaenv");
 
 // azure storage
 var storage = builder.AddAzureStorage("readrstorage")
-                     .RunAsEmulator();
+                     //.RunAsEmulator()
+                     ;
 
 var readrblobs = storage.AddBlobs("readrblobs");
 var readrqueues = storage.AddQueues("readrqueues");
@@ -19,6 +23,9 @@ var functions = builder.AddAzureFunctionsProject<Projects.ReadR_Serverless>("fun
                        .WaitFor(readrqueues)
                        .WithReference(readrblobs)
                        .WithReference(readrqueues)
+                       .WithEnvironment("readrblobs__blobServiceUri", readrblobs)
+                       .WithEnvironment("readrqueues__queueServiceUri", readrqueues)
+                       .WithReference(readrinsights)
                        .WithRoleAssignments(storage,
                             StorageBuiltInRole.StorageBlobDataOwner,
                             StorageBuiltInRole.StorageQueueDataContributor,
@@ -35,7 +42,10 @@ var frontend = builder.AddProject<Projects.ReadR_Frontend>("frontend")
                       .WaitFor(readrblobs)
                       .WaitFor(functions)
                       .WithReference(readrqueues)
+                      .WithEnvironment("readrblobs__blobServiceUri", readrblobs)
+                      .WithEnvironment("readrqueues__queueServiceUri", readrqueues)
                       .WithReference(readrblobs)
+                      .WithReference(readrinsights)
                       .WithRoleAssignments(storage,
                            StorageBuiltInRole.StorageBlobDataOwner,
                            StorageBuiltInRole.StorageQueueDataContributor,

--- a/ReadR.AppHost/ReadR.AppHost.csproj
+++ b/ReadR.AppHost/ReadR.AppHost.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.AppHost" Version="9.4.0" />
+    <PackageReference Include="Aspire.Hosting.Azure.ApplicationInsights" Version="9.4.0" />
     <PackageReference Include="Aspire.Hosting.Azure.Functions" Version="9.4.0-preview.1.25378.8" />
     <PackageReference Include="Aspire.Hosting.Azure.Storage" Version="9.4.0" />
     <PackageReference Include="Aspire.Hosting.Azure.AppContainers" Version="9.4.0" />

--- a/ReadR.Frontend/Program.cs
+++ b/ReadR.Frontend/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Azure;
 using ReadR.Frontend.Services;
 using ReadR.Shared.Services;
+using Azure.Identity;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -41,6 +42,16 @@ builder.Services.AddScoped<IHomePageService, HomePageService>();
 
 // Add background service for queue monitoring
 builder.Services.AddHostedService<QueueBackgroundService>();
+
+// Application Insights telemetry configuration
+builder.Services.AddApplicationInsightsTelemetry(new Microsoft.ApplicationInsights.AspNetCore.Extensions.ApplicationInsightsServiceOptions
+{
+    ConnectionString = builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]
+});
+builder.Services.AddApplicationInsightsTelemetry(new Microsoft.ApplicationInsights.AspNetCore.Extensions.ApplicationInsightsServiceOptions
+{
+    ConnectionString = builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]
+});
 
 var app = builder.Build();
 

--- a/ReadR.Frontend/Properties/serviceDependencies.json
+++ b/ReadR.Frontend/Properties/serviceDependencies.json
@@ -12,6 +12,11 @@
       "type": "storage",
       "connectionId": "readrblobs",
       "dynamicId": null
+    },
+    "appInsights1": {
+      "type": "appInsights",
+      "connectionId": "APPLICATIONINSIGHTS_CONNECTION_STRING",
+      "dynamicId": null
     }
   }
 }

--- a/ReadR.Frontend/ReadR.Frontend.csproj
+++ b/ReadR.Frontend/ReadR.Frontend.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>a0f4d0a8-14e9-4ffd-95c7-967cdbe20ca4</UserSecretsId>
+    <ApplicationInsightsResourceId>/subscriptions/1136a23b-ebc0-4c06-992a-2c343fcdce4b/resourceGroups/rg-readrdev20250802003/providers/microsoft.insights/components/ReadRFrontend</ApplicationInsightsResourceId>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,6 +13,7 @@
 	<PackageReference Include="Azure.Storage.Blobs" Version="12.24.1" />
 	<PackageReference Include="Azure.Storage.Files.Shares" Version="12.22.0" />
 	<PackageReference Include="Azure.Storage.Queues" Version="12.22.0" />
+	<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
 	<PackageReference Include="Microsoft.Extensions.Azure" Version="1.12.0" />
     <PackageReference Include="System.ServiceModel.Syndication" Version="8.0.0" />
     <PackageReference Include="Aspire.Azure.Storage.Blobs" Version="9.4.0" />

--- a/ReadR.ServiceDefaults/Extensions.cs
+++ b/ReadR.ServiceDefaults/Extensions.cs
@@ -1,3 +1,4 @@
+using Azure.Monitor.OpenTelemetry.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.Extensions.DependencyInjection;
@@ -87,11 +88,11 @@ public static class Extensions
         }
 
         // Uncomment the following lines to enable the Azure Monitor exporter (requires the Azure.Monitor.OpenTelemetry.AspNetCore package)
-        //if (!string.IsNullOrEmpty(builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]))
-        //{
-        //    builder.Services.AddOpenTelemetry()
-        //       .UseAzureMonitor();
-        //}
+        if (!string.IsNullOrEmpty(builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]))
+        {
+            builder.Services.AddOpenTelemetry()
+               .UseAzureMonitor();
+        }
 
         return builder;
     }

--- a/ReadR.ServiceDefaults/ReadR.ServiceDefaults.csproj
+++ b/ReadR.ServiceDefaults/ReadR.ServiceDefaults.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.3.0" />
 
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.4.0" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.3.1" />

--- a/ReadR.Shared/Properties/launchSettings.json
+++ b/ReadR.Shared/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "ReadR.Shared": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:49477;http://localhost:49478"
+    }
+  }
+}


### PR DESCRIPTION
monitoring working end-to-end as well as other parts of the app. now you can run it, provision, publish, run locally, everything works *except* for still seeing the lack of the Function being triggerd properly when running as a Container App. 